### PR TITLE
feat: remove enum-to-string conversion in DTOs

### DIFF
--- a/frontend/src/views/contact-model.ts
+++ b/frontend/src/views/contact-model.ts
@@ -1,4 +1,5 @@
 import Contact from '../../generated/com/vaadin/tutorial/crm/backend/service/endpoint/Contact';
+import Status from '../../generated/com/vaadin/tutorial/crm/backend/entity/Contact/Status';
 
 export class ContactModel implements Contact {
   constructor(
@@ -7,6 +8,6 @@ export class ContactModel implements Contact {
     public email = '',
     public company = { name: '', employees: [] as Contact[], id: 0 },
     public id = 0,
-    public status = ''
+    public status = Status.Customer
   ) {}
 }

--- a/frontend/src/views/list-view.ts
+++ b/frontend/src/views/list-view.ts
@@ -15,6 +15,7 @@ import Contact from '../../generated/com/vaadin/tutorial/crm/backend/service/end
 import Company from '../../generated/com/vaadin/tutorial/crm/backend/service/endpoint/Company';
 import './contact-form';
 import { ContactModel } from './contact-model';
+import Status from "../../generated/com/vaadin/tutorial/crm/backend/entity/Contact/Status";
 
 @customElement('list-view')
 export class ListView extends LitElement {
@@ -28,7 +29,7 @@ export class ListView extends LitElement {
   private companies: Company[] = [];
 
   @property({ type: Array })
-  private statuses: string[] = [];
+  private statuses: Status[] = [];
 
   private filterText = '';
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <vaadin.version>17.0.0.alpha5</vaadin.version>
+        <flow.version>3.2-SNAPSHOT</flow.version>
 
         <drivers.dir>${project.basedir}/drivers</drivers.dir>
         <drivers.downloader.phase>pre-integration-test</drivers.downloader.phase>
@@ -33,7 +34,7 @@
         <pluginRepository>
             <id>vaadin-prereleases</id>
             <url>https://maven.vaadin.com/vaadin-prereleases/</url>
-            <snapshots><enabled>false</enabled></snapshots>
+            <snapshots><enabled>true</enabled></snapshots>
         </pluginRepository>
     </pluginRepositories>
 
@@ -56,12 +57,19 @@
         <repository>
             <id>vaadin-prereleases</id>
             <url>https://maven.vaadin.com/vaadin-prereleases/</url>
-            <snapshots><enabled>false</enabled></snapshots>
+            <snapshots><enabled>true</enabled></snapshots>
         </repository>
     </repositories>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-bom</artifactId>
+                <version>${flow.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-bom</artifactId>
@@ -155,8 +163,8 @@
             -->
             <plugin>
                 <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-maven-plugin</artifactId>
-                <version>${vaadin.version}</version>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${flow.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -194,7 +202,7 @@
                     </plugin>
                     <plugin>
                         <groupId>com.vaadin</groupId>
-                        <artifactId>vaadin-maven-plugin</artifactId>
+                        <artifactId>flow-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <goals>

--- a/src/main/java/com/vaadin/tutorial/crm/backend/service/endpoint/Contact.java
+++ b/src/main/java/com/vaadin/tutorial/crm/backend/service/endpoint/Contact.java
@@ -1,5 +1,7 @@
 package com.vaadin.tutorial.crm.backend.service.endpoint;
 
+import com.vaadin.tutorial.crm.backend.entity.Contact.Status;
+
 public class Contact {
 
   public Contact() {
@@ -10,7 +12,7 @@ public class Contact {
     firstName = dbContact.getFirstName();
     lastName = dbContact.getLastName();
     company = new Company(dbContact.getCompany());
-    status = dbContact.getStatus().toString();
+    status = dbContact.getStatus();
     email = dbContact.getEmail();
   }
 
@@ -22,7 +24,7 @@ public class Contact {
 
   private Company company;
 
-  private String status;
+  private Status status;
 
   private String email = "";
 
@@ -42,11 +44,11 @@ public class Contact {
     this.email = email;
   }
 
-  public String getStatus() {
+  public Status getStatus() {
     return status;
   }
 
-  public void setStatus(String status) {
+  public void setStatus(Status status) {
     this.status = status;
   }
 

--- a/src/main/java/com/vaadin/tutorial/crm/backend/service/endpoint/ServiceEndpoint.java
+++ b/src/main/java/com/vaadin/tutorial/crm/backend/service/endpoint/ServiceEndpoint.java
@@ -30,8 +30,8 @@ public class ServiceEndpoint {
     return contactService.findAll(filter).stream().map(Contact::new).collect(Collectors.toList());
   }
 
-  public List<String> getContactStatuses() {
-    return Arrays.asList(Status.values()).stream().map(Status::toString).collect(Collectors.toList());
+  public Status[] getContactStatuses() {
+    return Status.values();
   }
 
   public void saveContact(Contact contact) {
@@ -41,7 +41,7 @@ public class ServiceEndpoint {
     dbContact.setFirstName(contact.getFirstName());
     dbContact.setLastName(contact.getLastName());
     dbContact.setEmail(contact.getEmail());
-    dbContact.setStatus(Status.valueOf(contact.getStatus()));
+    dbContact.setStatus(contact.getStatus());
 
     if (dbContact.getCompany() == null || !contact.getCompany().getId().equals(dbContact.getCompany().getId())) {
       companyService.findById(contact.getCompany().getId()).ifPresent(c -> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "sourceMap": true,
     "inlineSources": true,
     "module": "esNext",
-    "target": "es2017",
+    "target": "es2019",
     "moduleResolution": "node",
     "strict": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
The enum-to-string conversion was used because V15 does not support passing Enums through endpoints. Now V17 supports that and this conversion becomes unnecessary.

See vaadin/flow#8144
~Depends on https://github.com/vaadin-learning-center/crm-tutorial-typescript/pull/4~