### PR TITLE
fix: login form was disabled after 2nd failed login

### DIFF
--- a/frontend/components/login-view/login-view.ts
+++ b/frontend/components/login-view/login-view.ts
@@ -51,6 +51,7 @@ export class LoginView extends LitElement implements AfterEnterObserver {
   }
 
   async login(event: CustomEvent) {
+    this.error = false;
     const result = await login(event.detail.username, event.detail.password);
     this.error = result.error;
     this.errorTitle = result.errorTitle;


### PR DESCRIPTION
On submit the `vaadin-login-form` sets `error` to `false` and `disabled` to `true`. Then the `disabled` status is removed only if `error` is set to `true` (via observer `_errorChanged(error)`).

The issue was that Lit property bindings are one way so when login form sets its internal error status to false, our `login-view` still has `error` `true` (after first login failure) and when we try login for the second time then `this.error = result.error;` doesn't do anything because `this.error` is already `true` (in our view), so it doesn't change and it doesn't trigger the propagation of `error` `true` into login form component.

Fixes #21