### PR TITLE
chore: bump spring version to 2.4.0

### DIFF
--- a/.travis.script.sh
+++ b/.travis.script.sh
@@ -7,4 +7,4 @@
 
 TESTBENCH=-Dvaadin.proKey=$VAADIN_PRO_KEY
 
-xvfb-run  --server-args="-screen 0 1024x768x24" mvn -B -e -V -U clean verify -DrunLint -Pit,production $TESTBENCH
+xvfb-run  --server-args="-screen 0 1024x768x24" mvn -B -e -V clean verify -DrunLint -Pit,production $TESTBENCH

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.6.RELEASE</version>
+        <version>2.4.0</version>
     </parent>
 
     <pluginRepositories>


### PR DESCRIPTION
Travis build was failing, seems the 2.3.6.RELEASE version could not be found there, update to 2.4.0 seems fixes the problem