### PR TITLE
Fix/is user logged in handling

### DIFF
--- a/frontend/auth.ts
+++ b/frontend/auth.ts
@@ -1,0 +1,38 @@
+import { login as loginImpl, logout as logoutImpl } from '@vaadin/flow-frontend';
+import type { LoginResult } from '@vaadin/flow-frontend';
+
+const LAST_LOGIN_TIMESTAMP = 'lastLoginTimestamp';
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+const lastLoginTimestamp = localStorage.getItem(LAST_LOGIN_TIMESTAMP);
+const hasRecentLoginTimestamp = (lastLoginTimestamp &&
+  (new Date().getTime() - new Date(+lastLoginTimestamp).getTime()) < THIRTY_DAYS_MS) || false;
+
+let _isLoggedIn = hasRecentLoginTimestamp;
+
+export async function login(username: string, password: string): Promise<LoginResult> {
+  if (_isLoggedIn) {
+    return { error: false } as LoginResult;
+  } else {
+    const result = await loginImpl(username, password);
+    if (!result.error) {
+      _isLoggedIn = true;
+      localStorage.setItem(LAST_LOGIN_TIMESTAMP, new Date().getTime() + '')
+    }
+    return result;
+  }
+}
+
+export async function logout() {
+  _isLoggedIn = false;
+  localStorage.removeItem(LAST_LOGIN_TIMESTAMP);
+  return await logoutImpl();
+}
+
+export function isLoggedIn() {
+  return _isLoggedIn;
+}
+
+export function setSessionExpired() {
+  _isLoggedIn = false;
+  localStorage.removeItem(LAST_LOGIN_TIMESTAMP);
+}

--- a/frontend/components/login-view/login-view.ts
+++ b/frontend/components/login-view/login-view.ts
@@ -3,7 +3,8 @@ import { customElement, html, LitElement, property } from 'lit-element';
 import '@vaadin/vaadin-login/vaadin-login-overlay';
 import { LoginI18n } from '@vaadin/vaadin-login/@types/interfaces';
 import { Router, AfterEnterObserver, RouterLocation } from '@vaadin/router';
-import { LoginResult, login } from '@vaadin/flow-frontend';
+import type { LoginResult } from '@vaadin/flow-frontend';
+import { login } from '@vaadin/flow-frontend';
 import { Lumo } from '../../utils/lumo';
 import styles from './login-view.css';
 
@@ -13,9 +14,6 @@ export class LoginView extends LitElement implements AfterEnterObserver {
   @property({type: Boolean})
   private error = false;
 
-  @property({type: Boolean})
-  private open = true;
-
   @property()
   private errorTitle = '';
 
@@ -24,7 +22,7 @@ export class LoginView extends LitElement implements AfterEnterObserver {
 
   private returnUrl = '/';
 
-  private onSuccess: (result:LoginResult) => void;
+  private onSuccess: (result: LoginResult) => void;
 
   static styles = [Lumo, styles];
 
@@ -36,20 +34,27 @@ export class LoginView extends LitElement implements AfterEnterObserver {
     };
   }
 
-  async showOverlay(): Promise<LoginResult>{
-    return new Promise(resolve => {
-      this.onSuccess = (result: LoginResult) => {
-        this.remove();
+  private static popupResult?: Promise<LoginResult>;
+  static async openAsPopup(): Promise<LoginResult> {
+    if (this.popupResult) {
+      return this.popupResult;
+    }
+
+    const popup = new this();
+    return this.popupResult = new Promise(resolve => {
+      popup.onSuccess = result => {
+        this.popupResult = undefined;
+        popup.remove();
         resolve(result);
       }
-      document.body.append(this);
+      document.body.append(popup);
     });
   }
 
   render() {
     return html`
       <vaadin-login-overlay
-        ?opened="${this.open}" 
+        opened 
         .error=${this.error}
         .i18n="${this.i18n}"
         @login="${this.login}">    

--- a/frontend/components/login-view/login-view.ts
+++ b/frontend/components/login-view/login-view.ts
@@ -4,7 +4,7 @@ import '@vaadin/vaadin-login/vaadin-login-overlay';
 import { LoginI18n } from '@vaadin/vaadin-login/@types/interfaces';
 import { Router, AfterEnterObserver, RouterLocation } from '@vaadin/router';
 import type { LoginResult } from '@vaadin/flow-frontend';
-import { login } from '@vaadin/flow-frontend';
+import { login } from '../../auth';
 import { Lumo } from '../../utils/lumo';
 import styles from './login-view.css';
 
@@ -29,7 +29,6 @@ export class LoginView extends LitElement implements AfterEnterObserver {
   constructor(){
     super();
     this.onSuccess = () => {
-      localStorage.setItem('loggedIn', String(true));
       Router.go(this.returnUrl);
     };
   }

--- a/frontend/connect-client.ts
+++ b/frontend/connect-client.ts
@@ -1,8 +1,0 @@
-import {ConnectClient, InvalidSessionMiddleware} from '@vaadin/flow-frontend';
-const client = new ConnectClient({prefix: 'connect', middlewares: [new InvalidSessionMiddleware(
-    async () => {
-        const {LoginView} = await import ('./components/login-view/login-view');
-        return new LoginView().showOverlay();
-    }
-)]});
-export default client;

--- a/frontend/index.ts
+++ b/frontend/index.ts
@@ -2,7 +2,7 @@ import { Commands, Context, Router } from '@vaadin/router';
 
 import './components/main-layout/main-layout';
 import './components/list-view/list-view';
-import { logout } from '@vaadin/flow-frontend';
+import { isLoggedIn, logout } from './auth';
 
 import './utils/lumo';
 import client from './generated/connect-client.default';
@@ -10,10 +10,6 @@ import { invalidSessionMiddleware } from './utils/invalid-session-middleware';
 
 // Show a login dialog in a popup when the user session expires
 client.middlewares.push(invalidSessionMiddleware);
-
-const isUserLoggedIn = function() {
-  return localStorage.getItem('loggedIn') === 'true';
-}
 
 const routes = [
   {
@@ -36,14 +32,13 @@ const routes = [
      path: '/logout',
      action: async (_: Context, commands: Commands) => {
        await logout();
-       localStorage.setItem('loggedIn', String(false));
        return commands.redirect('/');
      }
    },
   {
     path: '/',
     action: async (_: Router.Context, commands: Router.Commands) => {
-      if (!isUserLoggedIn()) {
+      if (!isLoggedIn()) {
         return commands.redirect('/login');
       }
       return undefined;

--- a/frontend/index.ts
+++ b/frontend/index.ts
@@ -5,6 +5,11 @@ import './components/list-view/list-view';
 import { logout } from '@vaadin/flow-frontend';
 
 import './utils/lumo';
+import client from './generated/connect-client.default';
+import { invalidSessionMiddleware } from './utils/invalid-session-middleware';
+
+// Show a login dialog in a popup when the user session expires
+client.middlewares.push(invalidSessionMiddleware);
 
 const isUserLoggedIn = function() {
   return localStorage.getItem('loggedIn') === 'true';

--- a/frontend/utils/invalid-session-middleware.ts
+++ b/frontend/utils/invalid-session-middleware.ts
@@ -1,7 +1,9 @@
 import { InvalidSessionMiddleware } from '@vaadin/flow-frontend';
+import { setSessionExpired } from '../auth';
 
 export const invalidSessionMiddleware = new InvalidSessionMiddleware(
   async () => {
+    setSessionExpired();
     const { LoginView } = await import ('../components/login-view/login-view');
     return LoginView.openAsPopup();
   }

--- a/frontend/utils/invalid-session-middleware.ts
+++ b/frontend/utils/invalid-session-middleware.ts
@@ -1,0 +1,8 @@
+import { InvalidSessionMiddleware } from '@vaadin/flow-frontend';
+
+export const invalidSessionMiddleware = new InvalidSessionMiddleware(
+  async () => {
+    const { LoginView } = await import ('../components/login-view/login-view');
+    return LoginView.openAsPopup();
+  }
+);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@vaadin/vaadin-grid": "5.7.7",
     "@vaadin/vaadin-split-layout": "4.3.0",
     "@vaadin/vaadin-combo-box": "5.4.6",
-    "@vaadin/vaadin-core-shrinkwrap": "18.0.0-rc2",
+    "@vaadin/vaadin-core-shrinkwrap": "18.0.1",
     "@vaadin/vaadin-upload": "4.4.1",
     "@vaadin/vaadin-dialog": "2.5.2",
     "@vaadin/vaadin-select": "2.4.0",
@@ -83,7 +83,7 @@
       "@vaadin/vaadin-grid": "5.7.7",
       "@vaadin/vaadin-split-layout": "4.3.0",
       "@vaadin/vaadin-combo-box": "5.4.6",
-      "@vaadin/vaadin-core-shrinkwrap": "18.0.0-rc2",
+      "@vaadin/vaadin-core-shrinkwrap": "18.0.1",
       "@vaadin/vaadin-upload": "4.4.1",
       "@vaadin/vaadin-dialog": "2.5.2",
       "@vaadin/vaadin-select": "2.4.0",
@@ -142,6 +142,6 @@
       "webpack-manifest-plugin": "2.2.0",
       "workbox-webpack-plugin": "5.1.4"
     },
-    "hash": "4c94065fe7b6f360a56ca42c9eb4b65bdc46549d243a76a47f16a7773d72f3a9"
+    "hash": "5d84f3f8abb70d9fca55c05fd11db1968a43fc47ee3af77a0bd72c3ecb692f6f"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ dependencies:
   '@vaadin/vaadin-checkbox': 2.5.0
   '@vaadin/vaadin-combo-box': 5.4.6
   '@vaadin/vaadin-context-menu': 4.5.0
-  '@vaadin/vaadin-core-shrinkwrap': 18.0.0-rc2
+  '@vaadin/vaadin-core-shrinkwrap': 18.0.1
   '@vaadin/vaadin-custom-field': 1.3.0
   '@vaadin/vaadin-date-picker': 4.4.1
   '@vaadin/vaadin-date-time-picker': 1.4.0
@@ -1352,7 +1352,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-a0a+Hh99fQ5ueKTmY6F0i94jOfdOwKFS9ppNs0amfQwO+Js5ZC84naLnyVMVtY87K98FQ1vEYqpzxDYZy6duPw==
-  /@vaadin/vaadin-core-shrinkwrap/18.0.0-rc2:
+  /@vaadin/vaadin-core-shrinkwrap/18.0.1:
     dependencies:
       '@polymer/iron-a11y-announcer': 3.0.2
       '@polymer/iron-a11y-keys-behavior': 3.0.1
@@ -1408,7 +1408,7 @@ packages:
       '@webcomponents/shadycss': 1.9.4
     dev: false
     resolution:
-      integrity: sha512-9cgNL4Oanm3wwy8P2izzkwdw5wAhpVNnFKY062/8FRkd+oyzk6j7TWK2bsXl/Wd6HqEOCg4EjOn3FmylO3wPRQ==
+      integrity: sha512-1qURLyXrPKGiU8SoXV/CYCaM0RxDhrN5K0hhqnD2Va/H+iogZgxA5orkeXrfqOqz0dqjkYsL7qpgg6DEiiejfA==
   /@vaadin/vaadin-custom-field/1.3.0:
     dependencies:
       '@polymer/polymer': 3.2.0
@@ -8070,7 +8070,7 @@ specifiers:
   '@vaadin/vaadin-checkbox': 2.5.0
   '@vaadin/vaadin-combo-box': 5.4.6
   '@vaadin/vaadin-context-menu': 4.5.0
-  '@vaadin/vaadin-core-shrinkwrap': 18.0.0-rc2
+  '@vaadin/vaadin-core-shrinkwrap': 18.0.1
   '@vaadin/vaadin-custom-field': 1.3.0
   '@vaadin/vaadin-date-picker': 4.4.1
   '@vaadin/vaadin-date-time-picker': 1.4.0


### PR DESCRIPTION
Merge without squashing

fix: show only one login popup at a time
fix: update 'isUserLogged' in local storage when session expires
feat: add a 30 days expiration on the `isUserLogged` flag in the local storage
refactor: remove the 'magic' `connect-client.ts` file
refactor: collect the `isUserLogged` flag handling in a single file: `auth.ts`